### PR TITLE
docs: create .env.example and simplified mongodb login url

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+STATUSPAGE_PAGEID="gytm4qzbx9t6"
+STATUSPAGE_METRICID="cm7f8dghrtzn"
+STATUSPAGE_APIKEY="89a229ce1a8dbcf9ff30430fbe35eb4c0426574bca932061892cefd2138aa4b1"
+MONGO_URL="mongodb://username:password@http://127.0.0.1/:27017"

--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,4 @@
 STATUSPAGE_PAGEID="gytm4qzbx9t6"
 STATUSPAGE_METRICID="cm7f8dghrtzn"
 STATUSPAGE_APIKEY="89a229ce1a8dbcf9ff30430fbe35eb4c0426574bca932061892cefd2138aa4b1"
-MONGO_URL="mongodb://username:password@http://127.0.0.1/:27017"
+MONGO_URL="mongodb://username:password@127.0.0.1:27017"

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -3,7 +3,7 @@ import { MongoClient as mClient, Db } from "mongodb";
 export let pmdDB: Db = null;
 
 export const client = new mClient(
-	`mongodb://${process.env.MONGO_USERNAME}:${process.env.MONGO_PASSWORD}@${process.env.MONGO_IP}:27017`,
+	process.env.MONGO_URL,
 	{
 		appname: "PreMiD-API",
 		useUnifiedTopology: true


### PR DESCRIPTION
This PR adds minimal changes:
- Created example of the .env file for documentation porpuses.
- Simplified the MongoDB login URL because having all 3 individual credentials stored separately wasn't necessary since they weren't being used anywhere else.