### PR TITLE
Add new API endpoints to support Presence localizations

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -9,7 +9,11 @@
 			"handler": "ping"
 		},
 		{
-			"path": ["/app/update", "/app/update/:bit", "/app/update/*"],
+			"path": [
+				"/app/update",
+				"/app/update/:bit",
+				"/app/update/*"
+			],
 			"handler": "appUpdate"
 		},
 		{
@@ -49,19 +53,32 @@
 			"handler": "versions"
 		},
 		{
-			"path": ["/v2/langFile/:project/:lang", "/v2/langFile/list"],
+			"path": [
+				"/v2/langFile/list",
+				"/v2/langFile/:project/:lang",
+				"/v2/langFile/:project/list"
+			],
 			"handler": "langFile"
 		},
 		{
-			"path": ["/v2/credits", "/v2/credits/:userId"],
+			"path": [
+				"/v2/credits",
+				"/v2/credits/:userId"
+			],
 			"handler": "credits"
 		},
 		{
-			"path": ["/v2/betaAccess", "/v2/betaAccess/:userId"],
+			"path": [
+				"/v2/betaAccess",
+				"/v2/betaAccess/:userId"
+			],
 			"handler": "betaAccess"
 		},
 		{
-			"path": ["/v2/alphaAccess", "/v2/alphaAccess/:userId"],
+			"path": [
+				"/v2/alphaAccess",
+				"/v2/alphaAccess/:userId"
+			],
 			"handler": "alphaAccess"
 		},
 		{

--- a/src/endpoints/v2/langFile.ts
+++ b/src/endpoints/v2/langFile.ts
@@ -6,7 +6,7 @@ cache.onUpdate("langFiles", data => (langFiles = prepareLangFiles(data)));
 
 //* Request Handler
 const handler: RequestHandler = (req, res) => {
-  if (req.path.endsWith("/list")) {
+  if (req.path.endsWith("/list") && !req.params["project"]) {
     res.send(
       langFiles
         .filter(lF => lF.project === "extension")
@@ -36,19 +36,72 @@ const handler: RequestHandler = (req, res) => {
     return;
   }
 
-  if (!req.params["project"] || !req.params["lang"]) {
+  let langFile;
+  const projectParamLwr = req.params["project"].toLowerCase();
+
+  // get strings of given project name
+  if (["extension", "website", "presence"].includes(req.params["project"])) {
+
+    langFile = langFiles.find(
+      lF => lF.project === req.params["project"] && lF.lang === req.params["lang"]
+    );
+
+  } else {
+    const masterLangFile = langFiles.find(
+      lF => lF.project === "presence" && lF.lang === "en"
+    );
+    const masterLangKeys = Object.keys(masterLangFile.translations);
+
+    if (!masterLangKeys.find(
+      key => key.startsWith(`${projectParamLwr}_`)
+    )) {
+      res.sendStatus(404);
+      return;
+    }
+
+    // list 100% translated locales for given presence
+    if (req.path.endsWith("/list")) {
+      let referenceKeys = masterLangKeys.filter(
+        keyName => keyName.startsWith(`${projectParamLwr}_`) || keyName.startsWith(`general_`)
+      );
+
+      const locales = [];
+      for (const langFile of langFiles.filter(lF => lF.project === "presence")) {
+        let fileKeys = Object.keys(langFile.translations).filter(
+          lF => lF.startsWith(`${projectParamLwr}_`) || lF.startsWith(`general_`)
+        );
+
+        if (fileKeys.length === referenceKeys.length) {
+          locales.push(langFile.lang);
+        }
+      }
+
+    return res.send(locales);
+
+    // get presence strings in given language
+    } else if (req.params["lang"]) {
+      let allStrings = langFiles.find(lF => lF.project === "presence" && lF.lang === req.params["lang"]);
+
+      if (!allStrings) {
+        return res.sendStatus(404);
+      }
+
+      allStrings = formatLangFile(allStrings);
+
+      const strings = {};
+
+      for (const key of Object.keys(allStrings)) {
+        if (key.startsWith(`${projectParamLwr}.`)) {
+          strings[key] = allStrings[key];
+        }
+      }
+
+      return res.send(strings);
+    }
+
     res.sendStatus(404);
     return;
   }
-
-  if (!["extension", "website"].includes(req.params["project"])) {
-    res.send(404);
-    return;
-  }
-
-  let langFile = langFiles.find(
-    lF => lF.project === req.params["project"] && lF.lang === req.params["lang"]
-  );
 
   if (!langFile) {
     res.send({ error: 6, message: "No translations found." });
@@ -57,18 +110,20 @@ const handler: RequestHandler = (req, res) => {
 
   langFile = { translations: langFile.translations };
 
-  res.send(
-    Object.assign(
-      {},
-      ...Object.keys(langFile.translations).map(translationKey => {
-        const newKey = translationKey.replace(/[_]/g, ".");
-        return {
-          [newKey]: langFile.translations[translationKey]
-        };
-      })
-    )
-  );
+  res.send(formatLangFile(langFile));
 };
+
+function formatLangFile(langFile) {
+  return Object.assign(
+    {},
+    ...Object.keys(langFile.translations).map(translationKey => {
+      const newKey = translationKey.replace(/[_]/g, ".");
+      return {
+        [newKey]: langFile.translations[translationKey]
+      };
+    })
+  );
+}
 
 function prepareLangFiles(langFiles) {
   langFiles.map(lF => {


### PR DESCRIPTION
### New added endpoints

* /v2/langFile/presence/&lt;langCode&gt; → all the presence strings in the given language code.
* /v2/langFile/&lt;presenceName&gt;/list → all the languages that are completelly translated for the given presence. If the presence has no localization support a 404 error code is returned.
* /v2/langFile/&lt;presenceName&gt;/&lt;langCode&gt; → all the strings of a presence in the given language code. This might return strings on languages that are not listed in the list endpoint (/v2/langFile/&lt;presenceName&gt;/list) but some strings are missing. If the presence and language combination does not exist a 404 error code is returned.