### PR TITLE
Add GET method to /v2/science, mimics DELETE method of same endpoint

### DIFF
--- a/src/endpoints.json
+++ b/src/endpoints.json
@@ -32,6 +32,10 @@
 			"handler": "science"
 		},
 		{
+			"path": "/v2/science/:identifier",
+			"handler": "science"
+		},
+		{
 			"method": "delete",
 			"path": "/v2/science",
 			"handler": "science"

--- a/src/endpoints/v2/science.ts
+++ b/src/endpoints/v2/science.ts
@@ -35,16 +35,41 @@ const handler: RequestHandler = (req, res) => {
 			)
 			.then(() => res.sendStatus(200))
 			.catch(() => res.sendStatus(500));
-	} else if (req.method === "DELETE") {
-		if (!req.body.identifier) {
+
+	} else {
+
+		let identifier;
+
+		if (req.method === "DELETE") {
+			if (!req.body.identifier) {
+				res.sendStatus(404);
+				return;
+			}
+
+			identifier = req.body.identifier;
+
+		} else if (req.method === "GET") {
+			if (!req.params.identifier) {
+				res.sendStatus(404);
+				return;
+			}
+
+			identifier = req.params.identifier;
+
+		} else {
 			res.sendStatus(404);
 			return;
 		}
 
 		science
-			.findOneAndDelete({ identifier: req.body.identifier })
+			.findOneAndDelete({ identifier: identifier })
 			.then(response => {
-				if (response.value) res.sendStatus(200);
+				if (response.value) {
+					if (req.method === "DELETE")
+						res.sendStatus(200);
+					else
+						res.redirect("https://premid.app");
+				}
 				else res.sendStatus(404);
 			})
 			.catch(() => res.sendStatus(500));


### PR DESCRIPTION
This endpoint will be hit when a user uninstall the browser extension; the given identifier will be deleted from the database and a redirect to https://premid.app will be returned.

TLDR; mimic the `DELETE` method of the same endpoint.